### PR TITLE
Changed which to that in License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## FarmData2 Licensing Information ##
 
-FarmData2 is a [Free Cultural Work].  This document outlines the licenses that apply to FarmData2 and the agreement which governs contributions.  Complete copies of these documents can be be found in the [licenses directory]. All copies and forks of FarmData2 must be maintained in compliance with those licenses.
+FarmData2 is a [Free Cultural Work].  This document outlines the licenses that apply to FarmData2 and the agreement that governs contributions.  Complete copies of these documents can be be found in the [licenses directory]. All copies and forks of FarmData2 must be maintained in compliance with those licenses.
 
 [Free Cultural Work]: https://freedomdefined.org/Definition
 [licenses directory]: licenses


### PR DESCRIPTION
__Pull Request Description__

Changed "which" to "that" in the first paragraph of LICENSE.md for clarity. Fixes #26

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
