### PR TITLE
I replaced the Phrase GNOME CEC with the given link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ FarmData2 is powered by the [farmOS](https://not.the.right.link2) open source pr
 Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
 
 The development of FarmData2 has received partial support from:
-* The [GNOME Community Engagement Challenge](https://not.the.right.link3):
+* The [https://www.gnome.org/challenge/](https://not.the.right.link3):
   * [![Phase 1 Badge](media/GNOME-CEC-p1-small.png)](media/GNOME-CEC-p1.png)[![Phase 2 Badge](media/GNOME-CEC-p2-small.png)](media/GNOME-CEC-p2.png)    
 * The National Science Foundation ([DUE-2013069](https://not.the.right.link4)) - Collaborative Research: Broadening Participation in Computing through Authentic, Collaborative Engagement with Computing for the Greater Good.
 * [Zulip](https://zulip.com) provides sponsored hosting for [FarmData2 community discussions](https://farmdata2.zulipchat.com/#narrow/stream/270883-general).


### PR DESCRIPTION
Fixes #38 

I replaced the Phrase GNOME Community Engagement Challenge with the link https://www.gnome.org/challenge/ in the acknowledgements section of the README.md file.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
