### PR TITLE
Changed farmOSlink to correct link, fixing Round 2 Issue #39

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Having a running version of FarmData2 is a prerequisite for many of the forms of
 
 #### Bug Reports ####
 
-If you are are a user of FarmData2 and discover something that doesn't seem to be working correctly you can:
+If you are a user of FarmData2 and discover something that doesn't seem to be working correctly you can:
 
   * Reach out to the community on the [Zulip Developer Stream](https://farmdata2.zulipchat.com/#narrow/stream/271292-developers) to discuss what you have found and how to proceed.
   * Search the [Issue Tracker] to see if the bug has been reported already.
@@ -37,7 +37,7 @@ If you are are a user of FarmData2 and discover something that doesn't seem to b
 
 #### Feature Requests ####
 
-If you are are a user of FarmData2 and have a new feature you would like to see you can:
+If you are a user of FarmData2 and have a new feature you would like to see you can:
 
   * Reach out to the community on the [Zulip Developer Stream](https://farmdata2.zulipchat.com/#narrow/stream/271292-developers) to discuss the feature you'd like to see and how to proceed.
   * Search the [Issue Tracker] to see if the feature, or something close, has already been suggested by someone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Having a running version of FarmData2 is a prerequisite for many of the forms of
 
 #### Bug Reports ####
 
-If you are a user of FarmData2 and discover something that doesn't seem to be working correctly you can:
+If you are are a user of FarmData2 and discover something that doesn't seem to be working correctly you can:
 
   * Reach out to the community on the [Zulip Developer Stream](https://farmdata2.zulipchat.com/#narrow/stream/271292-developers) to discuss what you have found and how to proceed.
   * Search the [Issue Tracker] to see if the bug has been reported already.
@@ -37,7 +37,7 @@ If you are a user of FarmData2 and discover something that doesn't seem to be wo
 
 #### Feature Requests ####
 
-If you are a user of FarmData2 and have a new feature you would like to see you can:
+If you are are a user of FarmData2 and have a new feature you would like to see you can:
 
   * Reach out to the community on the [Zulip Developer Stream](https://farmdata2.zulipchat.com/#narrow/stream/271292-developers) to discuss the feature you'd like to see and how to proceed.
   * Search the [Issue Tracker] to see if the feature, or something close, has already been suggested by someone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Having a running version of FarmData2 is a prerequisite for many of the forms of
 
 #### Bug Reports ####
 
-If you are a user of FarmData2 and discover something that doesn't seem to be working correctly you can:
+If you are are a user of FarmData2 and discover something that doesn't seem to be working correctly you can:
 
   * Reach out to the community on the [Zulip Developer Stream](https://farmdata2.zulipchat.com/#narrow/stream/271292-developers) to discuss what you have found and how to proceed.
   * Search the [Issue Tracker] to see if the bug has been reported already.
@@ -37,7 +37,7 @@ If you are a user of FarmData2 and discover something that doesn't seem to be wo
 
 #### Feature Requests ####
 
-If you are a user of FarmData2 and have a new feature you would like to see you can:
+If you are are a user of FarmData2 and have a new feature you would like to see you can:
 
   * Reach out to the community on the [Zulip Developer Stream](https://farmdata2.zulipchat.com/#narrow/stream/271292-developers) to discuss the feature you'd like to see and how to proceed.
   * Search the [Issue Tracker] to see if the feature, or something close, has already been suggested by someone.
@@ -47,7 +47,7 @@ If you are a user of FarmData2 and have a new feature you would like to see you 
 #### Issue Gardening ####
 
 The project [Issue Tracker] contains tickets describing known issues with the project.  The tickets for known issues are tagged with the label "bug".  Each reported bug will have a detailed description of how the bug can be observed. Gardening includes activities such as:
-
+  
   * Verifying or clarifying these descriptions.
   * Enhance the report by providing additional information about the bug (e.g. platforms on which is is or is not seen).
   * Confirming that bug does (or does not) exist in the current version.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integr
 
 ### Acknowledgements ###
 
-FarmData2 is powered by the farmOS open source project.
+FarmData2 is powered by the [https://farmos.org/](https://farmos.org/) open source project.
 
 Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
 


### PR DESCRIPTION
__Pull Request Description__

Modified the README.md file to have the correct link to farmOS under the subheading Acknowledgments.
Closes #39
---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
